### PR TITLE
Fixes an error when nodes were removed from the networkx graph

### DIFF
--- a/code/FINDER_CN/FINDER.pyx
+++ b/code/FINDER_CN/FINDER.pyx
@@ -844,6 +844,10 @@ class FINDER:
         print('restore model from file successfully')
 
     def GenNetwork(self, g):    #networkx2four
+        mapping = {}
+        for i, j in zip(sorted(g), [sorted(g).index(i) for i in sorted(g)]):
+            mapping[i] = j
+        g = nx.relabel_nodes(g, mapping)
         edges = g.edges()
         if len(edges) > 0:
             a, b = zip(*edges)

--- a/code/FINDER_CN_cost/FINDER.pyx
+++ b/code/FINDER_CN_cost/FINDER.pyx
@@ -1003,6 +1003,10 @@ class FINDER:
 
 
     def GenNetwork(self, g):    #networkx2four
+        mapping = {}
+        for i, j in zip(sorted(g), [sorted(g).index(i) for i in sorted(g)]):
+            mapping[i] = j
+        g = nx.relabel_nodes(g, mapping)
         nodes = g.nodes()
         edges = g.edges()
         weights = []

--- a/code/FINDER_ND/FINDER.pyx
+++ b/code/FINDER_ND/FINDER.pyx
@@ -821,6 +821,10 @@ class FINDER:
         print('restore model from file successfully')
 
     def GenNetwork(self, g):    #networkx2four
+        mapping = {}
+        for i, j in zip(sorted(g), [sorted(g).index(i) for i in sorted(g)]):
+            mapping[i] = j
+        g = nx.relabel_nodes(g, mapping)
         edges = g.edges()
         if len(edges) > 0:
             a, b = zip(*edges)

--- a/code/FINDER_ND_cost/FINDER.pyx
+++ b/code/FINDER_ND_cost/FINDER.pyx
@@ -877,6 +877,10 @@ class FINDER:
 
 
     def GenNetwork(self, g):    #networkx2four
+        mapping = {}
+        for i, j in zip(sorted(g), [sorted(g).index(i) for i in sorted(g)]):
+            mapping[i] = j
+        g = nx.relabel_nodes(g, mapping)
         nodes = g.nodes()
         edges = g.edges()
         weights = []


### PR DESCRIPTION
If you create a networkx graph from an edge list where a component is disconnected, FINDER will fail and raise a std::bad_alloc.

This happened because the GenNetwork function created an array of length g.nodes(), but indexed it with the original names of the node.

Example:
```
>>> test = np.array([0, 0, 0, 1], [0, 0, 0, 1], [0, 0, 0, 1], [1, 1, 1, 0]])
>>> g = nx.from_numpy_array(test)
>>> g.remove_node(2)
>>> 
>>> # some more detail:
>>> a, b = zip(*g.edges())
>>> a
(0, 1)
>>> b    # <<< Here is the error!
(3, 3)
>>> len(g.nodes())
3
```

The resulting graph can not be processed with finder.

This patch resolves this and makes handling of such graphs possible. 